### PR TITLE
Relax highline requirement to 1.6

### DIFF
--- a/lib/sekrets.rb
+++ b/lib/sekrets.rb
@@ -383,7 +383,7 @@ BEGIN {
       def dependencies
         {
           'openssl'  => [ 'openssl'  , ' ~> 3.2'   ] ,
-          'highline' => [ 'highline' , ' ~> 1.7'   ] ,
+          'highline' => [ 'highline' , ' ~> 1.6'   ] ,
           'map'      => [ 'map'      , ' ~> 6.6'   ] ,
           'fattr'    => [ 'fattr'    , ' ~> 2.4'   ] ,
           'coerce'   => [ 'coerce'   , ' ~> 0.0.8' ] ,

--- a/sekrets.gemspec
+++ b/sekrets.gemspec
@@ -38,19 +38,19 @@ Gem::Specification::new do |spec|
 
   spec.test_files = nil
 
-  
+
     spec.add_dependency(*["openssl", " ~> 3.2"])
-  
-    spec.add_dependency(*["highline", " ~> 1.7"])
-  
+
+    spec.add_dependency(*["highline", " ~> 1.6"])
+
     spec.add_dependency(*["map", " ~> 6.6"])
-  
+
     spec.add_dependency(*["fattr", " ~> 2.4"])
-  
+
     spec.add_dependency(*["coerce", " ~> 0.0.8"])
-  
+
     spec.add_dependency(*["main", " ~> 6.3"])
-  
+
 
   spec.extensions.push(*[])
 


### PR DESCRIPTION
Previous versions of the sekrets gem worked fine with highline 1.6. There are no new features in highline 1.7+ that are used in the sekrets gem and there are no security fixes either that would mandate an upgrade.